### PR TITLE
Misc fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ install:
     - sudo add-apt-repository ppa:webupd8team/sublime-text-3 -y
     - sudo apt-get update
     - sudo apt-get install sublime-text-installer golang -y
-    - go get code.google.com/p/codesearch/cmd/cindex
-    - go get code.google.com/p/codesearch/cmd/csearch
+    - go get github.com/google/codesearch/cmd/...
     - mkdir -p $HOME/.config/sublime-text-3/Packages
     - ln -s $PWD $HOME/.config/sublime-text-3/Packages/YetAnotherCodeSearch
     - git clone --branch 0.4.3 https://github.com/randy3k/UnitTesting $HOME/.config/sublime-text-3/Packages/UnitTesting

--- a/Code Search Results.YAML-tmLanguage
+++ b/Code Search Results.YAML-tmLanguage
@@ -12,7 +12,7 @@ patterns:
 
 - match: '^ +([0-9]+) '
   captures:
-    '1': {name: constant.numeric.line-number.cearch}
+    '1': {name: constant.numeric.line-number.csearch}
 
 - match: '^ +([0-9]+):'
   captures:

--- a/Code Search Results.hidden-tmLanguage
+++ b/Code Search Results.hidden-tmLanguage
@@ -26,7 +26,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>constant.numeric.line-number.cearch</string>
+					<string>constant.numeric.line-number.csearch</string>
 				</dict>
 			</dict>
 			<key>match</key>

--- a/Default (Linux).sublime-mousemap
+++ b/Default (Linux).sublime-mousemap
@@ -1,0 +1,8 @@
+[
+	{
+		"button": "button1", "count": 2,
+		"press_command": "drag_select",
+		"press_args": {"by": "words"},
+		"command": "double_click_callback"
+	},
+]

--- a/Default (OSX).sublime-mousemap
+++ b/Default (OSX).sublime-mousemap
@@ -1,0 +1,8 @@
+[
+	{
+		"button": "button1", "count": 2,
+		"press_command": "drag_select",
+		"press_args": {"by": "words"},
+		"command": "double_click_callback"
+	},
+]

--- a/Default (Windows).sublime-mousemap
+++ b/Default (Windows).sublime-mousemap
@@ -1,0 +1,8 @@
+[
+	{
+		"button": "button1", "count": 2,
+		"press_command": "drag_select",
+		"press_args": {"by": "words"},
+		"command": "double_click_callback"
+	},
+]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -4,11 +4,11 @@
     "command": "csearch"
   },
   {
-    "caption": "Code Search Index",
+    "caption": "Code Search: Refresh Index",
     "command": "cindex"
   },
   {
-    "caption": "Code Search Index Project",
+    "caption": "Code Search: Create New Index from Project Settings",
     "command": "cindex",
     "args": {
       "index_project": true

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ specific `YetAnotherCodeSearch.sublime-settings` file. See the default file
 for configuration options. Both are easily found via
 *Preferences > Package Settings > YetAnotherCodeSearch*.
 
+To add keyboard shortcut open Preferences > Key Bindings - User and add
+something like `{ "keys": ["alt+ctrl+shift+f"], "command": "csearch" }`.
+
 ### Project Settings
 
 You can specify an index file to use for the project by editing the project

--- a/settings.py
+++ b/settings.py
@@ -3,6 +3,17 @@ import sublime
 import os.path
 
 
+def fix_path(path, project_dir=None):
+    """Resolves absolute path:
+        absolute path is reported as is
+        resolve paths with user home (~)
+        other relative paths resolved against project dir"""
+    path = os.path.expanduser(path)
+    if not os.path.isabs(path) and project_dir:
+        path = os.path.join(project_dir, path)
+    return os.path.abspath(path)
+
+
 class Settings(object):
     """Code search settings for the project.
 
@@ -18,7 +29,7 @@ class Settings(object):
         self.csearch_path = csearch_path
         self.cindex_path = cindex_path
         self.index_filename = index_filename
-        self.paths_to_index = paths_to_index
+        self.paths_to_index = paths_to_index or []
 
     def __eq__(self, other):
         return (isinstance(other, self.__class__) and
@@ -41,11 +52,14 @@ class Settings(object):
                         self.index_filename, self.paths_to_index)
 
 
-def get_project_settings(project_data, index_project_folders=False):
+def get_project_settings(project_data,
+                         project_file_name=None,
+                         index_project_folders=False):
     """Gets the Code Search settings for the current project.
 
     Args:
         project_data: The project data associated for a window as a dict.
+        project_file_name: path to project settings file.
         index_project_folders: A boolean which specifies if we should use the
             project's folders as our starting points for indexing files.
     Returns:
@@ -59,17 +73,16 @@ def get_project_settings(project_data, index_project_folders=False):
     path_csearch = settings.get('path_csearch')
     index_filename = None
     paths_to_index = []
-    if ('code_search' in project_data and
-            'csearchindex' in project_data['code_search']):
-        raw_index_filename = project_data['code_search']['csearchindex']
-        index_filename = os.path.abspath(
-            os.path.expanduser(raw_index_filename))
-        if not os.path.isfile(index_filename) and not index_project_folders:
-            raise Exception(
-                'The index file, {}, does not exist'.format(index_filename))
+    project_dir = None
+    if project_file_name:
+        project_dir = os.path.dirname(project_file_name)
+    if ('code_search' in project_data):
+        if 'csearchindex' in project_data['code_search']:
+            index_filename = fix_path(
+                project_data['code_search']['csearchindex'], project_dir)
 
     if index_project_folders:
-        paths_to_index = [os.path.abspath(os.path.expanduser(folder['path']))
+        paths_to_index = [fix_path(folder['path'], project_dir)
                           for folder in project_data['folders']]
 
     return Settings(path_csearch, path_cindex,

--- a/tests/test_cindex.py
+++ b/tests/test_cindex.py
@@ -14,7 +14,8 @@ class CindexCommandTest(CommandTestCase):
         self.window.run_command('cindex', {'index_project': True})
         max_iters = 10
         while (max_iters > 0 and
-               self.view.get_status('YetAnotherCodeSearch') != ''):
+               (self.view.get_status('YetAnotherCodeSearch') != '' or
+                not os.path.isfile(self.index))):
             time.sleep(0.1)
             max_iters -= 1
         self.assertEquals('', self.view.get_status('YetAnotherCodeSearch'))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -23,16 +23,14 @@ class ParseQueryTest(unittest.TestCase):
 
     def test_quoted_string(self):
         self.assertParse(r'"Hello, \"World\"" printf',
-                         query=[r'"Hello, \"World\""', 'printf'])
+                         query=[r'Hello, \"World\"', 'printf'])
 
-    # TODO(pope): Make this give a warning. At least this proves we don't loop
-    # infinitely for this value.
     def test_quoted_string_without_closing_quote(self):
-        self.assertParse(r'"Hello', query=['"Hello'])
+        self.assertParse(r'"Hello', query=['Hello'])
 
     def test_with_file(self):
         self.assertParse(r'"Hello, World" file:.*py$',
-                         query=[r'"Hello, World"'], file='.*py$')
+                         query=[r'Hello, World'], file='.*py$')
 
     def test_case_insensitive(self):
         self.assertParse(r'someVariableName case:no',
@@ -66,8 +64,8 @@ class SearchTest(unittest.TestCase):
                           ['(hello|world)'])
 
     def test_args_with_quoted_string(self):
-        self.assertEquals(parser.Search(query=['"Hello, world"']).args(),
-                          ['"Hello, world"'])
+        self.assertEquals(parser.Search(query=['Hello, world']).args(),
+                          ['Hello, world'])
 
 
 class ParseSearchOutputTest(unittest.TestCase):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,55 +5,67 @@ from unittest.mock import patch
 from YetAnotherCodeSearch import settings
 
 
+def abspath(x):
+    return x if x.startswith('/') else '/abs/' + x
+
+
+def expanduser(x):
+    return x.replace('~', '/abs/home/you')
+
+
 class GetProjectSettingsTest(unittest.TestCase):
 
     def setUp(self):
         self.project_data = {
             'code_search': {
-                'csearchindex': 'csearchindex'},
+                'csearchindex': '/abs/csearchindex'},
             'folders': [
                 {'path': '~/bar'},
-                {'path': '~/foo'}]}
+                {'path': '~/foo'},
+                {'path': 'src'}]}
+        self.project_file_name = '/abs/project/test.project'
 
+    @patch('os.path.isabs', autospec=True)
     @patch('os.path.abspath', autospec=True)
     @patch('os.path.expanduser', autospec=True)
     @patch('os.path.isfile', autospec=True)
     def test_get_project_settings(self, mock_isfile, mock_expanduser,
-                                  mock_abspath):
-        mock_expanduser.side_effect = lambda x: x.replace('~', 'home/you')
-        mock_abspath.side_effect = lambda x: '/abs/' + x
+                                  mock_abspath, mock_isabs):
+        mock_expanduser.side_effect = expanduser
+        mock_abspath.side_effect = abspath
         mock_isfile.return_value = True
+        mock_isabs.side_effect = lambda x: x.startswith('/')
 
         s = settings.get_project_settings(self.project_data,
+                                          self.project_file_name,
                                           index_project_folders=True)
         self.assertEquals(s.paths_to_index, ['/abs/home/you/bar',
-                                             '/abs/home/you/foo'])
+                                             '/abs/home/you/foo',
+                                             '/abs/project/src'])
         self.assertEquals(s.index_filename, '/abs/csearchindex')
         # Test the basename here incase someone is testing and has their own
         # user settings.
         self.assertEquals(os.path.basename(s.cindex_path), 'cindex')
         self.assertEquals(os.path.basename(s.csearch_path), 'csearch')
 
-    @patch('os.path.isfile', autospec=True)
-    def test_raises_exception_if_index_file_is_missing(self, mock_isfile):
-        mock_isfile.return_value = False
-        with self.assertRaises(Exception):
-            settings.get_project_settings(self.project_data)
-
+    @patch('os.path.isabs', autospec=True)
     @patch('os.path.abspath', autospec=True)
     @patch('os.path.expanduser', autospec=True)
     @patch('os.path.isfile', autospec=True)
     def test_get_project_settings_when_indexing_project_and_no_index_set(
-            self, mock_isfile, mock_expanduser, mock_abspath):
-        mock_expanduser.side_effect = lambda x: x.replace('~', 'home/you')
-        mock_abspath.side_effect = lambda x: '/abs/' + x
+            self, mock_isfile, mock_expanduser, mock_abspath, mock_isabs):
+        mock_expanduser.side_effect = expanduser
+        mock_abspath.side_effect = abspath
         mock_isfile.return_value = True
+        mock_isabs.side_effect = lambda x: x.startswith('/')
 
         del self.project_data['code_search']
         s = settings.get_project_settings(self.project_data,
+                                          self.project_file_name,
                                           index_project_folders=True)
         self.assertEquals(s.paths_to_index, ['/abs/home/you/bar',
-                                             '/abs/home/you/foo'])
+                                             '/abs/home/you/foo',
+                                             '/abs/project/src'])
         self.assertIsNone(s.index_filename)
         self.assertEquals(os.path.basename(s.cindex_path), 'cindex')
         self.assertEquals(os.path.basename(s.csearch_path), 'csearch')


### PR DESCRIPTION
Here is a list of fixes I have done while using the plugin. There is no "exclude paths" option for #6 yet as my [PR](https://github.com/google/codesearch/pull/57) is on the way to codesearch project.
- fix typo in `constant.numeric.line-number.csearch`
- ~~add hotkey to invoke code search. Hotkey is `alt-super-shift-f`
  (not `alt-super-shift-s` as in SublimeCodeSearch project) as if it's an
  "extension" to normal "find in files" `super-shift-f`~~
- #5 add handling of double clicks within search results to open target file.
  That might conflict with other extensions trying to mimic "Find in files"
  double click behaviour. I blame Jon Skinner.
- updated captions of commands to better explain what they do
- add handling of paths relative to project root
- fix searching for qouted text: now qoutes are not passed along
- removed TODO: now we handle missing closing qoute assuming it is at very end
- updated default search prompt to `file:* case:yes "` to:
  - showcase `file` and `case` options
  - be able to simply paste multi-word search (you had to add quotas before
    otherwise it searches for `(multi-word|search)`)
- fix handling of windows paths: parser failed to process paths with colons
  rendering plugin useless on windows
- removed throwing an error when index file does not exist: you had to run
  cindex manually to bootstrap project index. cindex can create new files
  with ease
- add log to console how much time it took to index
